### PR TITLE
refactor: configs, `filename()`

### DIFF
--- a/scripts/DeployFrxEthFpi/DeployFrxEthFpi.s.sol
+++ b/scripts/DeployFrxEthFpi/DeployFrxEthFpi.s.sol
@@ -18,30 +18,18 @@ contract DeployFrxEThFpis is DeployFraxOFTProtocol {
     using Strings for uint256;
 
     function version() public virtual override pure returns (uint256, uint256, uint256) {
-        return (1, 0, 1);
+        return (1, 0, 2);
     }
 
     /// @dev override to alter file save location
-    modifier simulateAndWriteTxs(L0Config memory _config) override {
-        // Clear out arrays
-        delete enforcedOptionsParams;
-        delete setConfigParams;
-        delete serializedTxs;
-
-        vm.createSelectFork(_config.RPC);
-        chainid = _config.chainid;
-        vm.startPrank(_config.delegate);
-        _;
-        vm.stopPrank();
-
-        // create filename and save
+    function filename() public view override returns (string memory) {
         string memory root = vm.projectRoot();
         root = string.concat(root, "/scripts/DeployFrxEthFpi/txs/");
-        string memory filename = string.concat(activeConfig.chainid.toString(), "-");
-        filename = string.concat(filename, _config.chainid.toString());
-        filename = string.concat(filename, ".json");
+        string memory name = string.concat(broadcastConfig.chainid.toString(), "-");
+        name = string.concat(name, simulateConfig.chainid.toString());
+        name = string.concat(name, ".json");
 
-        new SafeTxUtil().writeTxs(serializedTxs, string.concat(root, filename));
+        return string.concat(root, name);
     }
 
 
@@ -88,12 +76,12 @@ contract DeployFrxEThFpis is DeployFraxOFTProtocol {
     function setPriviledgedRoles() public virtual override {
         for (uint256 o=0; o<proxyOfts.length; o++) {
             address proxyOft = proxyOfts[o];
-            FraxOFTUpgradeable(proxyOft).setDelegate(activeConfig.delegate);
-            Ownable(proxyOft).transferOwnership(activeConfig.delegate);
+            FraxOFTUpgradeable(proxyOft).setDelegate(broadcastConfig.delegate);
+            Ownable(proxyOft).transferOwnership(broadcastConfig.delegate);
         }
 
         /// @dev transfer ownership of ProxyAdmin
-        // Ownable(proxyAdmin).transferOwnership(activeConfig.delegate);
+        // Ownable(proxyAdmin).transferOwnership(broadcastConfig.delegate);
     }
 
 }

--- a/scripts/FixDVNs/FixDVNs.s.sol
+++ b/scripts/FixDVNs/FixDVNs.s.sol
@@ -12,25 +12,17 @@ contract FixDVNs is DeployFraxOFTProtocol {
     using stdJson for string;
     using Strings for uint256;
 
+    function version() public virtual override pure returns (uint256, uint256, uint256) {
+        return (1, 0, 1);
+    }
+
     /// @dev override to alter file save location
-    modifier simulateAndWriteTxs(L0Config memory _config) override {
-        // Clear out arrays
-        delete enforcedOptionsParams;
-        delete setConfigParams;
-        delete serializedTxs;
-
-        vm.createSelectFork(_config.RPC);
-        chainid = _config.chainid;
-        vm.startPrank(_config.delegate);
-        _;
-        vm.stopPrank();
-
-        // create filename and save
+    function filename() public view override returns (string memory) {
         string memory root = vm.projectRoot();
         root = string.concat(root, "/scripts/FixDVNs/txs/");
-        string memory filename = string.concat(_config.chainid.toString(), "-fixed.json");
-        string memory filepath = string.concat(root, filename);
-        new SafeTxUtil().writeTxs(serializedTxs, filepath);
+        string memory name = string.concat(simulateConfig.chainid.toString(), "-fixed.json");
+
+        return string.concat(root, name);
     }
 
     function setUp() public override {
@@ -44,7 +36,7 @@ contract FixDVNs is DeployFraxOFTProtocol {
     }
 
     /// @dev simulating the active config delegate to create the new DVN txs
-    function setupSource() public override simulateAndWriteTxs(activeConfig) {
+    function setupSource() public override simulateAndWriteTxs(broadcastConfig) {
         // // TODO: this will break if proxyOFT addrs are not the pre-determined addrs verified in postDeployChecks()
         // setEnforcedOptions({
         //     _connectedOfts: proxyOfts,
@@ -52,7 +44,7 @@ contract FixDVNs is DeployFraxOFTProtocol {
         // });
 
         setDVNs({
-            _connectedConfig: activeConfig,
+            _connectedConfig: broadcastConfig,
             _connectedOfts: proxyOfts,
             _configs: configs
         });

--- a/scripts/FixDeployFpi/FixDeployFpi.s.sol
+++ b/scripts/FixDeployFpi/FixDeployFpi.s.sol
@@ -17,32 +17,19 @@ contract FixDeployFpi is DeployFraxOFTProtocol {
     using Strings for uint256;
 
     function version() public virtual override pure returns (uint256, uint256, uint256) {
-        return (1, 0, 0);
+        return (1, 0, 1);
     }
 
     /// @dev override to alter file save location
-    modifier simulateAndWriteTxs(L0Config memory _config) override {
-        // Clear out arrays
-        delete enforcedOptionsParams;
-        delete setConfigParams;
-        delete serializedTxs;
-
-        vm.createSelectFork(_config.RPC);
-        chainid = _config.chainid;
-        vm.startPrank(_config.delegate);
-        _;
-        vm.stopPrank();
-
-        // create filename and save
+    function filename() public view override returns (string memory) {
         string memory root = vm.projectRoot();
         root = string.concat(root, "/scripts/FixDeployFpi/txs/");
-        string memory filename = string.concat(activeConfig.chainid.toString(), "-");
-        filename = string.concat(filename, _config.chainid.toString());
-        filename = string.concat(filename, ".json");
+        string memory name = string.concat(broadcastConfig.chainid.toString(), "-");
+        name = string.concat(name, simulateConfig.chainid.toString());
+        name = string.concat(name, ".json");
 
-        new SafeTxUtil().writeTxs(serializedTxs, string.concat(root, filename));
+        return string.concat(root, name);
     }
-
 
     function setUp() public override {
         super.setUp();
@@ -85,12 +72,12 @@ contract FixDeployFpi is DeployFraxOFTProtocol {
     function setPriviledgedRoles() public virtual override {
         for (uint256 o=0; o<proxyOfts.length; o++) {
             address proxyOft = proxyOfts[o];
-            FraxOFTUpgradeable(proxyOft).setDelegate(activeConfig.delegate);
-            Ownable(proxyOft).transferOwnership(activeConfig.delegate);
+            FraxOFTUpgradeable(proxyOft).setDelegate(broadcastConfig.delegate);
+            Ownable(proxyOft).transferOwnership(broadcastConfig.delegate);
         }
 
         /// @dev transfer ownership of ProxyAdmin
-        // Ownable(proxyAdmin).transferOwnership(activeConfig.delegate);
+        // Ownable(proxyAdmin).transferOwnership(broadcastConfig.delegate);
     }
 
 }

--- a/scripts/SetupSolana/SetupSolana.s.sol
+++ b/scripts/SetupSolana/SetupSolana.s.sol
@@ -6,9 +6,9 @@ import "../DeployFraxOFTProtocol/DeployFraxOFTProtocol.s.sol";
 /// @dev creates 34443 files with set DVNs for all chains- 
 
 /*
-Goal: change _configs from activeConfigArray to all configs as setupSource uses configs.
+Goal: change _configs from broadcastConfigArray to all configs as setupSource uses configs.
 ie: through non-removal of old arrays (https://github.com/FraxFinance/frax-oft-upgradeable/pull/11),
-  the prior DVN configurations were overwritten in setupSource() with invalid activeConfigArray DVN addrs.
+  the prior DVN configurations were overwritten in setupSource() with invalid broadcastConfigArray DVN addrs.
 */
 
 contract SetupSolana is DeployFraxOFTProtocol {
@@ -18,7 +18,11 @@ contract SetupSolana is DeployFraxOFTProtocol {
 
     bytes32[] solanaPeers;
 
-    /// @dev comments out requirements at end and setting of activeConfig
+    function version() public virtual override pure returns (uint256, uint256, uint256) {
+        return (1, 0, 1);
+    }
+
+    /// @dev comments out requirements at end and setting of broadcastConfig
     function loadJsonConfig() public override {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/scripts/L0Config.json");
@@ -31,59 +35,47 @@ contract SetupSolana is DeployFraxOFTProtocol {
         for (uint256 i=0; i<legacyConfigs_.length; i++) {
             L0Config memory config_ = legacyConfigs_[i];
             // if (config_.chainid == chainid) {
-            //     activeConfig = config_;
-            //     activeConfigArray.push(config_);
+            //     broadcastConfig = config_;
+            //     broadcastConfigArray.push(config_);
             //     activeLegacy = true;
             // }
             legacyConfigs.push(config_);
             configs.push(config_);
         }
 
-        // proxy (active deployment loaded as activeConfig)
+        // proxy (active deployment loaded as broadcastConfig)
         L0Config[] memory proxyConfigs_ = abi.decode(json.parseRaw(".Proxy"), (L0Config[]));
         for (uint256 i=0; i<proxyConfigs_.length; i++) {
             L0Config memory config_ = proxyConfigs_[i];
             // if (config_.chainid == chainid) {
-            //     activeConfig = config_;
-            //     activeConfigArray.push(config_);
+            //     broadcastConfig = config_;
+            //     broadcastConfigArray.push(config_);
             //     activeLegacy = false;
             // }
             proxyConfigs.push(config_);
             configs.push(config_);
         }
-        // require(activeConfig.chainid != 0, "L0Config for source not loaded");
-        // require(activeConfigArray.length == 1, "ActiveConfigArray does not equal 1");
+        // require(broadcastConfig.chainid != 0, "L0Config for source not loaded");
+        // require(broadcastConfigArray.length == 1, "broadcastConfigArray does not equal 1");
     }
 
     /// @dev override to alter file save location
-    modifier simulateAndWriteTxs(L0Config memory _config) override {
-        // Clear out arrays
-        delete enforcedOptionsParams;
-        delete setConfigParams;
-        delete serializedTxs;
-
-        vm.createSelectFork(_config.RPC);
-        chainid = _config.chainid;
-        vm.startPrank(_config.delegate);
-        _;
-        vm.stopPrank();
-
-        // create filename and save
+    function filename() public view override returns (string memory) {
         string memory root = vm.projectRoot();
         root = string.concat(root, "/scripts/SetupSolana/txs/");
-        string memory filename = string.concat(_config.chainid.toString(), ".json");
-        
-        new SafeTxUtil().writeTxs(serializedTxs, string.concat(root, filename));
+        string memory name = string.concat(simulateConfig.chainid.toString(), ".json");
+
+        return string.concat(root, name);
     }
 
 
     function setUp() public override {
         super.setUp();
 
-        // Load solana as the activeConfig
+        // Load solana as the broadcastConfig
         L0Config[] memory nonEvmConfigs = abi.decode(json.parseRaw(".Non-EVM"), (L0Config[]));
-        activeConfig = nonEvmConfigs[0];
-        activeConfigArray.push(nonEvmConfigs[0]);
+        broadcastConfig = nonEvmConfigs[0];
+        broadcastConfigArray.push(nonEvmConfigs[0]);
 
         // push bytes32 token addrs in the same order as deployFraxOFTUpgradeblesAndProxies()
         solanaPeers.push(0x402e86d1cfd2cde4fac63aa8d9892eca6d3c0e08e8335622124332a95df6c10c); // fxs
@@ -107,19 +99,19 @@ contract SetupSolana is DeployFraxOFTProtocol {
     ) public override simulateAndWriteTxs(_connectedConfig) {
         setEnforcedOptions({
             _connectedOfts: _connectedOfts,
-            _configs: activeConfigArray
+            _configs: broadcastConfigArray
         });
 
         setDVNs({
             _connectedConfig: _connectedConfig,
             _connectedOfts: _connectedOfts,
-            _configs: activeConfigArray
+            _configs: broadcastConfigArray
         });
 
         setPeers({
             _connectedOfts: _connectedOfts,
             _peerOfts: solanaPeers,
-            _configs: activeConfigArray
+            _configs: broadcastConfigArray
         });
     }
 
@@ -137,7 +129,7 @@ contract SetupSolana is DeployFraxOFTProtocol {
             uint32 eid = uint32(_configs[c].eid);
 
             // cannot set enforced options to self
-            if (chainid == activeConfig.chainid && eid == activeConfig.eid) continue;
+            if (block.chainid == _configs[c].chainid) continue;
 
             enforcedOptionsParams.push(EnforcedOptionParam(eid, 1, optionsTypeOne));
             enforcedOptionsParams.push(EnforcedOptionParam(eid, 2, optionsTypeTwo));
@@ -178,7 +170,7 @@ contract SetupSolana is DeployFraxOFTProtocol {
                 uint32 eid = uint32(_configs[c].eid);
 
                 // cannot set peer to self
-                if (chainid == activeConfig.chainid && eid == activeConfig.eid) continue;
+                if (block.chainid == _configs[c].chainid) continue;
 
                 bytes memory data = abi.encodeCall(
                     IOAppCore.setPeer,

--- a/scripts/SubmitSends/SubmitSends.s.sol
+++ b/scripts/SubmitSends/SubmitSends.s.sol
@@ -9,7 +9,7 @@ contract SubmitSends is BaseL0Script {
     using Strings for uint256;
 
     function version() public pure override returns (uint256, uint256, uint256) {
-        return (1, 1, 1);
+        return (1, 1, 2);
     }
 
     function setUp() public override {
@@ -31,7 +31,7 @@ contract SubmitSends is BaseL0Script {
     ) public {
         for (uint256 c=0; c<configs.length; c++) {
             // Do not send if the target chain == active chain
-            if (configs[c].chainid == activeConfig.chainid) {
+            if (configs[c].chainid == broadcastConfig.chainid) {
                 continue;
             }
             for (uint256 o=0; o<_connectedOfts.length; o++) {


### PR DESCRIPTION
- Renames `activeConfig` to `broadcastConfig` for clarity
- Introduces `simulateConfig` to store config of the chain we're simulating
- Introduces `filename()` to sufficiently write the file location. Beforehand, `simulateAndWriteTxs()` had to be fully overriden, duplicating code across parent files. 